### PR TITLE
resend mail bug fix

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -139,7 +139,7 @@ class UsersController < ApplicationController
   end
 
   def resend_mail
-    if (@user.is?(current_user) || mod) && !confirmed?
+    if (@user.is?(current_user) || mod?) && !@user.confirmed?
       RedstonerMailer.register_mail(@user, false).deliver_now
       flash[:notice] = "Check your inbox for the confirmation mail."
     else


### PR DESCRIPTION
We can now send the mail when you are mod and you also don't need to be
unconfirmed yourself.

I have tested it and it isn't any security issues with it as far as I know.
I did test it in every possible way that could have bypassed as far as I know.
