### PR TITLE
Fixed list of donators link not including donorplus badge.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
     role = Role.find_by(name: params[:role])
     badge = Badge.find_by(name: params[:badge])
 
-    @users = User.search(params[:search], role, badge, params.include?(:staff))
+    @users = User.search(params[:search], role, badge, params.include?(:staff), params.include?(:donor))
     @count = @users.size
     @users = @users.page(params[:page]).per(100)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,12 +175,14 @@ class User < ActiveRecord::Base
     self.email_token ||= SecureRandom.hex(16)
   end
 
-  def self.search (search, role, badge, staff)
+  def self.search (search, role, badge, staff, donor)
     users = User.joins(:role)
     if role
       users = users.where(role: role)
     elsif staff
       users = users.where("roles.value >= ?", Role.get(:mod).to_i)
+    elsif donor
+      users = users.where("badge_id = ? OR badge_id = ?", Badge.get(:donor), Badge.get(:donorplus))
     end
     users = users.where(badge: badge) if badge
     if search

--- a/app/views/statics/donate.html.erb
+++ b/app/views/statics/donate.html.erb
@@ -11,7 +11,7 @@
   <li>Donator+ ($20 or more)
 </ul>
 
-<p>We also have <%= link_to "list of users who donated", users_path(badge: "donor") %> already!</p>
+<p>We also have <%= link_to "list of users who donated", users_path(donor: "") %> already!</p>
 
 <h3>Perks for you</h3>
 <p>For <i>Donator</i> and <i>Donator+</i></p>

--- a/app/views/statics/donate.html.erb
+++ b/app/views/statics/donate.html.erb
@@ -11,7 +11,7 @@
   <li>Donator+ ($20 or more)
 </ul>
 
-<p>We also have <%= link_to "list of users who donated", users_path(donor: "") %> already!</p>
+<p>We also have a <%= link_to "list of users who donated", users_path(donor: "") %> already!</p>
 
 <h3>Perks for you</h3>
 <p>For <i>Donator</i> and <i>Donator+</i></p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,6 +14,8 @@
       text = "All '#{params[:role]}' and '#{params[:badge]}' users"
     elsif params.include?(:staff)
       text = "All staff"
+    elsif params.include?(:donor)
+      text = "All donors"
     else
       text = "All users"
     end


### PR DESCRIPTION
This patch is intended to fix #37. Here's what it changes:
- Adds a "donors" param to `/users`, so `/users?donors` will return everyone with a donor or donorplus badge.
- Changes the "list of users who donated" link in `/donate` to point to `/users?donors` instead of `/users?badge=donor`.