### PR TITLE
Fixed staff link in emails going to wrong URL.

### DIFF
--- a/app/views/redstoner_mailer/email_change_confirm_mail.html.erb
+++ b/app/views/redstoner_mailer/email_change_confirm_mail.html.erb
@@ -13,7 +13,7 @@
       </div>
       <p></p>
 
-      <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(role: "staff"), style: "text-decoration: none; color: #4096EE;" %> in-game.</p>
+      <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(staff: ""), style: "text-decoration: none; color: #4096EE;" %> in-game.</p>
       <p>Your Redstoner team</p>
 
     </div>

--- a/app/views/redstoner_mailer/new_post_comment_mail.html.erb
+++ b/app/views/redstoner_mailer/new_post_comment_mail.html.erb
@@ -14,7 +14,7 @@
     %>
     <p><%= link_to "Click here", blogpost_url(@comment.blogpost, page: page) + "#comment-#{@comment.id}", style: "text-decoration: none; color: #4096EE;" %> to view the blog post.</p>
 
-    <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(role: "staff"), style: "text-decoration: none; color: #4096EE;" %> in-game or on the forums!</p>
+    <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(staff: ""), style: "text-decoration: none; color: #4096EE;" %> in-game or on the forums!</p>
     <p>Your Redstoner team</p>
 
   </div>

--- a/app/views/redstoner_mailer/new_post_mention_mail.html.erb
+++ b/app/views/redstoner_mailer/new_post_mention_mail.html.erb
@@ -10,7 +10,7 @@
 
     <p><%= link_to "Click here", blogpost_url(@post), style: "text-decoration: none; color: #4096EE;" %> to view the blog post.</p>
 
-      <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(role: "staff"), style: "text-decoration: none; color: #4096EE;" %> in-game or on the forums!</p>
+      <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(staff: ""), style: "text-decoration: none; color: #4096EE;" %> in-game or on the forums!</p>
       <p>Your Redstoner team</p>
 
     </div>

--- a/app/views/redstoner_mailer/new_thread_mention_mail.html.erb
+++ b/app/views/redstoner_mailer/new_thread_mention_mail.html.erb
@@ -11,7 +11,7 @@
 
     <p><%= link_to "Click here", forumthread_url(@thread), style: "text-decoration: none; color: #4096EE;" %> to view the thread.</p>
 
-      <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(role: "staff"), style: "text-decoration: none; color: #4096EE;" %> in-game or on the forums!</p>
+      <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(staff: ""), style: "text-decoration: none; color: #4096EE;" %> in-game or on the forums!</p>
       <p>Your Redstoner team</p>
 
     </div>

--- a/app/views/redstoner_mailer/new_thread_reply_mail.html.erb
+++ b/app/views/redstoner_mailer/new_thread_reply_mail.html.erb
@@ -15,7 +15,7 @@
     %>
     <p><%= link_to "Click here", forumthread_url(@reply.thread, page: page) + "#reply-#{@reply.id}", style: "text-decoration: none; color: #4096EE;" %> to view the thread.</p>
 
-    <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(role: "staff"), style: "text-decoration: none; color: #4096EE;" %> in-game or on the forums!</p>
+    <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(staff: ""), style: "text-decoration: none; color: #4096EE;" %> in-game or on the forums!</p>
     <p>Your Redstoner team</p>
 
   </div>

--- a/app/views/redstoner_mailer/register_mail.html.erb
+++ b/app/views/redstoner_mailer/register_mail.html.erb
@@ -25,7 +25,7 @@
       </div>
       <p></p>
 
-      <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(role: "staff"), style: "text-decoration: none; color: #4096EE;" %> in-game.</p>
+      <p>If you have any questions or problems, just ask one of our <%= link_to "Staff", users_url(staff: ""), style: "text-decoration: none; color: #4096EE;" %> in-game.</p>
       <p>Your Redstoner team</p>
 
     </div>


### PR DESCRIPTION
This patch is intended to fix #39. Here's what it changes:
- Makes the staff link in emails point to `/users?staff` instead of `/users?role=staff`.