### PR TITLE
Changed the who's playing JSON file path.

### DIFF
--- a/app/controllers/statics_controller.rb
+++ b/app/controllers/statics_controller.rb
@@ -17,7 +17,7 @@ class StaticsController < ApplicationController
   end
 
   def online
-    json = JSON.parse(File.read("/etc/minecraft/redstoner/plugins/JavaUtils/players.json"))
+    json = JSON.parse(File.read("/etc/minecraft/redstoner/plugins/ModuleLoader/players.json"))
     @players = json["players"].collect!{ |p| User.find_by(uuid: p["UUID"].tr("-", "")) or User.new(name: p["name"], ign: p["name"], uuid: p["UUID"].tr("-", ""), role: Role.get("normal"), badge: Badge.get("none"), confirmed: true) }.sort_by!(&:role).reverse!
     @count = json["amount"]
   end


### PR DESCRIPTION
This patch is intended to ensure compatibility for the who's playing page when a file path changes in an upcoming ModuleLoader update. Here's what it changes:
- Makes the who's playing page reach it's JSON file through the changed file path.