### PR TITLE
Added the ability to encrypt notification emails with a public key.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'highlight_js-rails', github: 'RedstonerServer/highlight_js-rails'
 gem 'kaminari', github: 'jomo/kaminari', branch: 'patch-2' # pagination
 gem 'jquery-textcomplete-rails', github: 'RedstonerServer/jquery-textcomplete-rails' # @mentions
 gem 'actionpack-action_caching', github: 'antulik/actionpack-action_caching', ref: '8c6e52c69315d67437f480da5dce4b7c8737fb32'
+gem 'mail-gpg'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -352,7 +352,7 @@ class UsersController < ApplicationController
   end
 
   def user_params(add = [])
-    a = [:ign, :email, :password, :password_confirmation, :mail_own_thread_reply, :mail_other_thread_reply, :mail_own_blogpost_comment, :mail_other_blogpost_comment, :mail_mention] + add
+    a = [:ign, :email, :password, :password_confirmation, :mail_own_thread_reply, :mail_other_thread_reply, :mail_own_blogpost_comment, :mail_other_blogpost_comment, :mail_mention, :public_key] + add
     params.require(:user).permit(a)
   end
 end

--- a/app/mailers/redstoner_mailer.rb
+++ b/app/mailers/redstoner_mailer.rb
@@ -19,29 +19,49 @@ class RedstonerMailer < ActionMailer::Base
   def new_thread_mention_mail(user, thread)
     @user   = user
     @thread = thread
-    mail(to: @user.email, subject: "#{thread.author.name} mentioned you in '#{thread.title}' on Redstoner")
+    if @user.public_key?
+      mail(to: @user.email, subject: "Encrypted Notification from Redstoner", gpg: {encrypt: true, keys: {@user.email => @user.public_key}})
+    else
+      mail(to: @user.email, subject: "#{thread.author.name} mentioned you in '#{thread.title}' on Redstoner")
+    end
   end
 
   def new_thread_reply_mail(user, reply)
     @user  = user
     @reply = reply
-    mail(to: @user.email, subject: "#{reply.author.name} replied to '#{reply.thread.title}' on Redstoner")
+    if @user.public_key?
+      mail(to: @user.email, subject: "Encrypted Notification from Redstoner", gpg: {encrypt: true, keys: {@user.email => @user.public_key}})
+    else
+      mail(to: @user.email, subject: "#{reply.author.name} replied to '#{reply.thread.title}' on Redstoner")
+    end
   end
 
   def new_post_mention_mail(user, post)
     @user = user
     @post = post
-    mail(to: @user.email, subject: "#{post.author.name} mentioned you in '#{post.title}' on Redstoner")
+    if @user.public_key?
+      mail(to: @user.email, subject: "Encrypted Notification from Redstoner", gpg: {encrypt: true, keys: {@user.email => @user.public_key}})
+    else
+      mail(to: @user.email, subject: "#{post.author.name} mentioned you in '#{post.title}' on Redstoner")
+    end
   end
 
   def new_post_comment_mail(user, comment)
     @user    = user
     @comment = comment
-    mail(to: @user.email, subject: "#{comment.author.name} replied to '#{comment.blogpost.title}' on Redstoner")
+    if @user.public_key?
+      mail(to: @user.email, subject: "Encrypted Notification from Redstoner", gpg: {encrypt: true, keys: {@user.email => @user.public_key}})
+    else
+      mail(to: @user.email, subject: "#{comment.author.name} replied to '#{comment.blogpost.title}' on Redstoner")
+    end
   end
 
   def email_change_confirm_mail(user)
     @user = user
-    mail(to: @user.email, subject: "Email change on Redstoner.com")
+    if @user.public_key?
+      mail(to: @user.email, subject: "Encrypted Notification from Redstoner", gpg: {encrypt: true, keys: {@user.email => @user.public_key}})
+    else
+      mail(to: @user.email, subject: "Email change on Redstoner.com")
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,8 @@ class User < ActiveRecord::Base
   validates :email, uniqueness: {case_sensitive: false}, format: {with: /\A.+@(.+\..{2,}|\[(IPv6)?[0-9a-f:.]+\])\z/i, message: "That doesn't look like an email address."}
   validates :ign, uniqueness: {case_sensitive: false}, format: {with: /\A[a-z\d_]+\z/i, message: "Username is invalid (a-z, 0-9, _)."}
 
+  validates :public_key, format: {with: /\A(-----BEGIN PGP PUBLIC KEY BLOCK-----((.|\n)*?)-----END PGP PUBLIC KEY BLOCK-----)?\z/i, message: "That doesn't look like a PGP formatted public key."}
+
   has_many :blogposts
   has_many :comments
 

--- a/app/views/users/edit_notifications.html.erb
+++ b/app/views/users/edit_notifications.html.erb
@@ -46,7 +46,7 @@
     </tbody>
   </table>
   <h3>Public Key</h1>
-  <p>All notification emails, including password resets, will be encrypted with this key if you supply it. <b>Do not lose your private key, otherwise you won't be able to easily recover your account.</b></p>
+  <p>All notification emails will be encrypted with this key if you supply it.</p>
   <%= f.text_area :public_key, placeholder: "-----BEGIN PGP PUBLIC KEY BLOCK-----" %>
   <p><%= f.submit "Save changes", class: "btn blue left" %></p>
   <div class="clear"></div>

--- a/app/views/users/edit_notifications.html.erb
+++ b/app/views/users/edit_notifications.html.erb
@@ -45,6 +45,9 @@
       </tr>
     </tbody>
   </table>
+  <h3>Public Key</h1>
+  <p>All notification emails, including password resets, will be encrypted with this key if you supply it. <b>Do not lose your private key, otherwise you won't be able to easily recover your account.</b></p>
+  <%= f.text_area :public_key, placeholder: "-----BEGIN PGP PUBLIC KEY BLOCK-----" %>
   <p><%= f.submit "Save changes", class: "btn blue left" %></p>
   <div class="clear"></div>
 <% end %>

--- a/db/migrate/20171013001146_add_public_key_to_users.rb
+++ b/db/migrate/20171013001146_add_public_key_to_users.rb
@@ -1,0 +1,5 @@
+class AddPublicKeyToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :public_key, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170703003647) do
+ActiveRecord::Schema.define(version: 20171013001146) do
 
   create_table "badges", force: :cascade do |t|
     t.string  "name",   limit: 191

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 20170703003647) do
     t.boolean  "utc_time",                                  default: false
     t.boolean  "header_scroll",                             default: false
     t.boolean  "dark",                                      default: false
+    t.text     "public_key",                  limit: 65535
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
This pull request is intended to add the ability to encrypt notification emails with a public key. Here's what it changes:
- Adds a public key field to the notification settings page.
- Makes the mailer encrypt emails if the recipient has a public key added to their account.