### PR TITLE
 Made Who's Playing page hide vanished users from non-staff ranks.

### DIFF
--- a/app/controllers/statics_controller.rb
+++ b/app/controllers/statics_controller.rb
@@ -34,7 +34,7 @@ class StaticsController < ApplicationController
         end
         @count = @players.count
       else
-        flash.now[:alert] = "The server is using an incompatible data format. Please report this error!"
+        flash.now[:alert] = "The server is using an incompatible data format. We are aware of this issue and are most likely already working on it."
       end
       @players.sort_by!(&:role).reverse!
     end


### PR DESCRIPTION
This pull request is intended to make vanished users hidden from the Who's Playing page if the page visitor is not of a staff rank. Here's what it changes:
- Makes the Who's Playing page hide vanished users if the page visitor is not of a staff rank.
- Adds foundation for supporting multiple data formats.