### PR TITLE
Added atom feed to forums.

### DIFF
--- a/app/views/forums/show.atom.builder
+++ b/app/views/forums/show.atom.builder
@@ -1,0 +1,19 @@
+atom_feed do |feed|
+  feed.title "Latest threads in " + @forum.name
+  feed.updated Time.now
+
+  @threads.limit(100).each do |thread|
+    unless thread.sticky?
+      feed.entry thread do |entry|
+        entry.updated thread.updated_at
+        entry.author do |a|
+          a.name thread.author.name
+          a.uri user_url(thread.author)
+        end
+        entry.url forumthread_url(thread)
+        entry.title thread.title
+        entry.content render_md(thread.content).html_safe, :type => 'html'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request is intended to add an atom feed to forums. Here's what it changes:
- Adds an atom feed to forums which can be accessed by appending `.atom` to the forum URL.