### PR TITLE
Added TOTP 2FA support.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'kaminari', github: 'jomo/kaminari', branch: 'patch-2' # pagination
 gem 'jquery-textcomplete-rails' # @mentions
 gem 'actionpack-action_caching', github: 'antulik/actionpack-action_caching', ref: '8c6e52c69315d67437f480da5dce4b7c8737fb32'
 gem 'mail-gpg', github: 'jomo/mail-gpg', ref: 'a666b48ee866dfa3eaa700f9c5edf4d195d0f8c9'
+gem 'totp'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.4)
+    base32 (0.3.2)
     bcrypt (3.1.11)
     better_errors (2.4.0)
       coderay (>= 1.0.0)
@@ -237,6 +238,8 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    totp (1.0.0)
+      base32
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.8)
@@ -277,10 +280,11 @@ DEPENDENCIES
   sass-rails
   sqlite3
   strip_attributes
+  totp
   tzinfo-data
   uglifier
   unicorn
   webrick
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  before_filter :update_ip, :update_seen, :check_banned
+  before_filter :update_ip, :update_seen, :check_banned, :check_2fa
   # TODO: use SSL
 
 
@@ -38,6 +38,14 @@ class ApplicationController < ActionController::Base
       session.delete(:user_id)
       flash[:alert] = "You are banned!"
       redirect_to login_path
+    end
+  end
+
+  def check_2fa
+    # Over complicated way of asking if the user is logged in as a mod without TOTP enabled while they are not on their login settings screen, logging out, or updating their login settings.
+    if current_user && current_user.mod? && !current_user.totp_enabled? && (!(controller_name == "users") || !(action_name == "edit_login")) && !(controller_name == "sessions" && action_name == "destroy") && !(action_name == "update_login")
+      flash[:alert] = "Due to your staff rank, you are required to enable 2FA."
+      redirect_to :controller => "users", :action => "edit_login", :id => current_user.id
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,7 +43,7 @@ class ApplicationController < ActionController::Base
 
   def check_2fa
     # Over complicated way of asking if the user is logged in as a mod without TOTP enabled while they are not on their login settings screen, logging out, or updating their login settings.
-    if current_user && current_user.mod? && !current_user.totp_enabled? && (!(controller_name == "users") || !(action_name == "edit_login")) && !(controller_name == "sessions" && action_name == "destroy") && !(action_name == "update_login")
+    if current_user && current_user.mod? && !current_user.totp_enabled? && !(controller_name == "users" && action_name == "edit_login") && !(controller_name == "sessions" && action_name == "destroy") && !(controller_name == "users" && action_name == "update_login")
       flash[:alert] = "Due to your staff rank, you are required to enable 2FA."
       redirect_to :controller => "users", :action => "edit_login", :id => current_user.id
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,6 +21,10 @@ class SessionsController < ApplicationController
           flash[:alert] = "Your account has been disabled!"
         elsif user.banned?
           flash[:alert] = "You are banned!"
+        elsif user.totp_enabled && !TOTP.verify?(user.totp_code, params[:totp_code])
+          flash[:alert] = "You're doing it wrong!"
+          render action: 'new'
+          return
         else
           session[:user_id] = user.id
           flash[:notice] = "Logged in!"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,7 +21,7 @@ class SessionsController < ApplicationController
           flash[:alert] = "Your account has been disabled!"
         elsif user.banned?
           flash[:alert] = "You are banned!"
-        elsif user.totp_enabled && !TOTP.valid?(user.totp_code, params[:totp_code])
+        elsif user.totp_enabled && !TOTP.valid?(user.totp_secret, params[:totp_code].to_i)
           flash[:alert] = "You're doing it wrong!"
           render action: 'new'
           return

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,7 +21,7 @@ class SessionsController < ApplicationController
           flash[:alert] = "Your account has been disabled!"
         elsif user.banned?
           flash[:alert] = "You are banned!"
-        elsif user.totp_enabled && !TOTP.verify?(user.totp_code, params[:totp_code])
+        elsif user.totp_enabled && !TOTP.valid?(user.totp_code, params[:totp_code])
           flash[:alert] = "You're doing it wrong!"
           render action: 'new'
           return

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -16,6 +16,14 @@
       <td></td>
       <td><%= link_to "Lost your password?", lost_password_users_path %></td>
     </tr>
+    <tr>
+      <td><%= label_tag :totp_code %></td>
+      <td><%= text_field_tag :totp_code, nil, placeholder: "123456", required: false %></td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>Leave this field blank if you do not have 2FA enabled.</td>
+    </tr>
   </table>
   <p><%= submit_tag "Log in", class: "btn blue" %></p>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -71,7 +71,7 @@
 
 <p><%= f.submit "Save Profile", class: "btn variable-size left", disabled: (!@user.confirmed? && @user.is?(current_user)) %></p>
 <p>
-  <%= link_to "Edit Login Details", edit_login_user_path(@user), class: "btn variable-size right" %>
+  <%= link_to "Login Settings", edit_login_user_path(@user), class: "btn variable-size right" %>
   <%= link_to "Notification Settings", edit_notifications_user_path(@user), class: "btn variable-size right" %>
   <%= link_to "Website Settings", edit_website_settings_user_path(@user), class: "btn variable-size right" %>
 </p>

--- a/app/views/users/edit_login.html.erb
+++ b/app/views/users/edit_login.html.erb
@@ -1,7 +1,7 @@
 <% title "Edit Login Credentials: #{@user.name}" %>
 
-<%= link_to @user.name, @user %> → Edit Login credentials
-<h1>Edit Login Credentials</h1>
+<%= link_to @user.name, @user %> → Edit Login settings
+<h1>Edit Login Settings</h1>
 
 
 <%= form_for @user, url: update_login_user_path(@user), method: :put do |f| %>

--- a/app/views/users/edit_login.html.erb
+++ b/app/views/users/edit_login.html.erb
@@ -25,12 +25,49 @@
           <%= f.password_field :password_confirmation %>
         </td>
       </tr>
+    </tbody>
+  </table>
+  <hr>
+  <table>
+    <tbody>
+      <tr>
+        <td>2FA Enabled</td>
+        <td>
+          <%= f.check_box :totp_enabled %>
+        </td>
+      </tr>
+      <tr>
+        <td>TOTP Secret</td>
+        <td>
+          <% if !@user.totp_enabled? %>
+          <%= f.text_field :totp_secret, :readonly => true %>
+          <% else %>
+          <i>2FA is currently enabled. Disable 2FA to generate a new secret.</i>
+          <% end %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <hr>
+  <table>
+    <tbody>
       <tr>
         <td>Current password</td>
         <td>
           <%= password_field_tag :current_password, nil, disabled: !@user.is?(current_user) %>
         </td>
       </tr>
+      <% if !@user.totp_enabled? %>
+      <tr>
+        <td>TOTP Code</td>
+        <td>
+          <%= text_field_tag :totp_code, nil, disabled: !@user.is?(current_user) %>
+        </td>
+      </tr>
+      <tr>
+        <td></td>
+        <td><i>Leave this field blank if you are not enabling 2FA.</i></td>
+      <% end %>
     </tbody>
   </table>
   <p><%= f.submit "Save Changes", class: "btn blue left" %></p>

--- a/db/migrate/20180606223258_add_totp_to_users.rb
+++ b/db/migrate/20180606223258_add_totp_to_users.rb
@@ -1,0 +1,5 @@
+class AddTotpToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :totp, :string
+  end
+end

--- a/db/migrate/20180606223258_add_totp_to_users.rb
+++ b/db/migrate/20180606223258_add_totp_to_users.rb
@@ -1,5 +1,6 @@
 class AddTotpToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :totp, :string
+    add_column :users, :totp_code, :string
+    add_column :users, :totp_enabled, :boolean, default: false
   end
 end

--- a/db/migrate/20180606223258_add_totp_to_users.rb
+++ b/db/migrate/20180606223258_add_totp_to_users.rb
@@ -1,6 +1,6 @@
 class AddTotpToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :totp_code, :string
+    add_column :users, :totp_secret, :string
     add_column :users, :totp_enabled, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,18 +11,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171013001146) do
+ActiveRecord::Schema.define(version: 20180606223258) do
 
   create_table "badges", force: :cascade do |t|
-    t.string  "name",   limit: 191
-    t.string  "symbol", limit: 191
-    t.string  "color",  limit: 191
-    t.integer "value",  limit: 4
+    t.string "name",   limit: 191
+    t.string "symbol", limit: 191
+    t.string "color",  limit: 191
   end
 
   create_table "blogposts", force: :cascade do |t|
-    t.string   "title",          limit: 255
-    t.text     "content",        limit: 16777215
+    t.string   "title",          limit: 191
+    t.text     "content",        limit: 65535
     t.integer  "user_author_id", limit: 4
     t.integer  "user_editor_id", limit: 4
     t.datetime "created_at"
@@ -30,7 +29,7 @@ ActiveRecord::Schema.define(version: 20171013001146) do
   end
 
   create_table "comments", force: :cascade do |t|
-    t.text     "content",        limit: 16777215
+    t.text     "content",        limit: 65535
     t.integer  "user_author_id", limit: 4
     t.integer  "user_editor_id", limit: 4
     t.integer  "blogpost_id",    limit: 4
@@ -39,14 +38,14 @@ ActiveRecord::Schema.define(version: 20171013001146) do
   end
 
   create_table "forumgroups", force: :cascade do |t|
-    t.string  "name",          limit: 255
+    t.string  "name",          limit: 191
     t.integer "position",      limit: 4
     t.integer "role_read_id",  limit: 4
     t.integer "role_write_id", limit: 4
   end
 
   create_table "forums", force: :cascade do |t|
-    t.string  "name",          limit: 255
+    t.string  "name",          limit: 191
     t.integer "position",      limit: 4
     t.integer "role_read_id",  limit: 4
     t.integer "role_write_id", limit: 4
@@ -60,10 +59,10 @@ ActiveRecord::Schema.define(version: 20171013001146) do
   end
 
   create_table "forumthreads", force: :cascade do |t|
-    t.string   "title",          limit: 255
-    t.text     "content",        limit: 16777215
-    t.boolean  "sticky",                          default: false
-    t.boolean  "locked",                          default: false
+    t.string   "title",          limit: 191
+    t.text     "content",        limit: 65535
+    t.boolean  "sticky",                       default: false
+    t.boolean  "locked",                       default: false
     t.integer  "user_author_id", limit: 4
     t.integer  "user_editor_id", limit: 4
     t.integer  "forum_id",       limit: 4
@@ -73,49 +72,47 @@ ActiveRecord::Schema.define(version: 20171013001146) do
   end
 
   add_index "forumthreads", ["content"], name: "index_forumthreads_on_content", type: :fulltext
-  add_index "forumthreads", ["title", "content"], name: "forumthreads_title_content", type: :fulltext
   add_index "forumthreads", ["title", "content"], name: "index_forumthreads_on_title_and_content", type: :fulltext
   add_index "forumthreads", ["title"], name: "index_forumthreads_on_title", type: :fulltext
 
   create_table "info", force: :cascade do |t|
-    t.string   "title",      limit: 255
-    t.text     "content",    limit: 16777215
+    t.string   "title",      limit: 191
+    t.text     "content",    limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "labels", force: :cascade do |t|
-    t.string "name",  limit: 255
-    t.string "color", limit: 255
+    t.string "name",  limit: 191
+    t.string "color", limit: 191
   end
 
   create_table "register_tokens", force: :cascade do |t|
     t.string "uuid",  limit: 32,  null: false
     t.string "token", limit: 6,   null: false
-    t.string "email", limit: 191
+    t.string "email", limit: 191, null: false
   end
 
-  add_index "register_tokens", ["email"], name: "index_register_tokens_on_email", unique: true, using: :btree
   add_index "register_tokens", ["uuid"], name: "index_register_tokens_on_uuid", unique: true, using: :btree
 
   create_table "roles", force: :cascade do |t|
-    t.string  "name",  limit: 255
+    t.string  "name",  limit: 191
     t.integer "value", limit: 4
-    t.string  "color", limit: 255
+    t.string  "color", limit: 191
   end
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", limit: 255,      null: false
-    t.text     "data",       limit: 16777215
+    t.string   "session_id", limit: 191,   null: false
+    t.text     "data",       limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", length: {"session_id"=>191}, using: :btree
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", using: :btree
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "threadreplies", force: :cascade do |t|
-    t.text     "content",        limit: 16777215
+    t.text     "content",        limit: 65535
     t.integer  "user_author_id", limit: 4
     t.integer  "user_editor_id", limit: 4
     t.integer  "forumthread_id", limit: 4
@@ -127,18 +124,18 @@ ActiveRecord::Schema.define(version: 20171013001146) do
   add_index "threadreplies", ["forumthread_id"], name: "index_threadreplies_on_forumthread_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "uuid",                        limit: 255,                   null: false
-    t.string   "name",                        limit: 191
-    t.string   "password_digest",             limit: 255,                   null: false
-    t.string   "ign",                         limit: 255,                   null: false
-    t.string   "email",                       limit: 191
+    t.string   "uuid",                        limit: 191,                   null: false
+    t.string   "name",                        limit: 191,                   null: false
+    t.string   "password_digest",             limit: 191,                   null: false
+    t.string   "ign",                         limit: 191,                   null: false
+    t.string   "email",                       limit: 191,                   null: false
     t.text     "about",                       limit: 65535
-    t.string   "last_ip",                     limit: 255
-    t.string   "skype",                       limit: 255
-    t.string   "youtube",                     limit: 255
-    t.string   "youtube_channelname",         limit: 255
-    t.string   "twitter",                     limit: 255
-    t.string   "email_token",                 limit: 255
+    t.string   "last_ip",                     limit: 191
+    t.string   "skype",                       limit: 191
+    t.string   "youtube",                     limit: 191
+    t.string   "youtube_channelname",         limit: 191
+    t.string   "twitter",                     limit: 191
+    t.string   "email_token",                 limit: 191
     t.boolean  "confirmed",                                 default: false
     t.datetime "last_seen"
     t.integer  "role_id",                     limit: 4,                     null: false
@@ -149,11 +146,12 @@ ActiveRecord::Schema.define(version: 20171013001146) do
     t.boolean  "mail_own_blogpost_comment",                 default: true
     t.boolean  "mail_other_blogpost_comment",               default: true
     t.boolean  "mail_mention",                              default: true
-    t.integer  "badge_id",                    limit: 4,     default: 0
+    t.integer  "badge_id",                    limit: 4,     default: 1
     t.boolean  "utc_time",                                  default: false
     t.boolean  "header_scroll",                             default: false
     t.boolean  "dark",                                      default: false
     t.text     "public_key",                  limit: 65535
+    t.string   "totp",                        limit: 191
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,7 +154,7 @@ ActiveRecord::Schema.define(version: 20180606223258) do
     t.boolean  "header_scroll",                             default: false
     t.boolean  "dark",                                      default: false
     t.text     "public_key",                  limit: 65535
-    t.string   "totp_code",                   limit: 255
+    t.string   "totp_string",                   limit: 255
     t.boolean  "totp_enabled",                              default: false
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,7 +154,8 @@ ActiveRecord::Schema.define(version: 20180606223258) do
     t.boolean  "header_scroll",                             default: false
     t.boolean  "dark",                                      default: false
     t.text     "public_key",                  limit: 65535
-    t.string   "totp",                        limit: 191
+    t.string   "totp_code",                   limit: 255
+    t.boolean  "totp_enabled",                              default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
@@ -166,4 +167,3 @@ ActiveRecord::Schema.define(version: 20180606223258) do
   add_index "users", ["youtube"], name: "index_users_on_youtube", unique: true, using: :btree
 
 end
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,7 +154,7 @@ ActiveRecord::Schema.define(version: 20180606223258) do
     t.boolean  "header_scroll",                             default: false
     t.boolean  "dark",                                      default: false
     t.text     "public_key",                  limit: 65535
-    t.string   "totp_string",                   limit: 255
+    t.string   "totp_secret",                   limit: 255
     t.boolean  "totp_enabled",                              default: false
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,14 +14,15 @@
 ActiveRecord::Schema.define(version: 20180606223258) do
 
   create_table "badges", force: :cascade do |t|
-    t.string "name",   limit: 191
-    t.string "symbol", limit: 191
-    t.string "color",  limit: 191
+    t.string  "name",   limit: 191
+    t.string  "symbol", limit: 191
+    t.string  "color",  limit: 191
+    t.integer "value",  limit: 4
   end
 
   create_table "blogposts", force: :cascade do |t|
-    t.string   "title",          limit: 191
-    t.text     "content",        limit: 65535
+    t.string   "title",          limit: 255
+    t.text     "content",        limit: 16777215
     t.integer  "user_author_id", limit: 4
     t.integer  "user_editor_id", limit: 4
     t.datetime "created_at"
@@ -29,7 +30,7 @@ ActiveRecord::Schema.define(version: 20180606223258) do
   end
 
   create_table "comments", force: :cascade do |t|
-    t.text     "content",        limit: 65535
+    t.text     "content",        limit: 16777215
     t.integer  "user_author_id", limit: 4
     t.integer  "user_editor_id", limit: 4
     t.integer  "blogpost_id",    limit: 4
@@ -38,14 +39,14 @@ ActiveRecord::Schema.define(version: 20180606223258) do
   end
 
   create_table "forumgroups", force: :cascade do |t|
-    t.string  "name",          limit: 191
+    t.string  "name",          limit: 255
     t.integer "position",      limit: 4
     t.integer "role_read_id",  limit: 4
     t.integer "role_write_id", limit: 4
   end
 
   create_table "forums", force: :cascade do |t|
-    t.string  "name",          limit: 191
+    t.string  "name",          limit: 255
     t.integer "position",      limit: 4
     t.integer "role_read_id",  limit: 4
     t.integer "role_write_id", limit: 4
@@ -59,10 +60,10 @@ ActiveRecord::Schema.define(version: 20180606223258) do
   end
 
   create_table "forumthreads", force: :cascade do |t|
-    t.string   "title",          limit: 191
-    t.text     "content",        limit: 65535
-    t.boolean  "sticky",                       default: false
-    t.boolean  "locked",                       default: false
+    t.string   "title",          limit: 255
+    t.text     "content",        limit: 16777215
+    t.boolean  "sticky",                          default: false
+    t.boolean  "locked",                          default: false
     t.integer  "user_author_id", limit: 4
     t.integer  "user_editor_id", limit: 4
     t.integer  "forum_id",       limit: 4
@@ -72,47 +73,49 @@ ActiveRecord::Schema.define(version: 20180606223258) do
   end
 
   add_index "forumthreads", ["content"], name: "index_forumthreads_on_content", type: :fulltext
+  add_index "forumthreads", ["title", "content"], name: "forumthreads_title_content", type: :fulltext
   add_index "forumthreads", ["title", "content"], name: "index_forumthreads_on_title_and_content", type: :fulltext
   add_index "forumthreads", ["title"], name: "index_forumthreads_on_title", type: :fulltext
 
   create_table "info", force: :cascade do |t|
-    t.string   "title",      limit: 191
-    t.text     "content",    limit: 65535
+    t.string   "title",      limit: 255
+    t.text     "content",    limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "labels", force: :cascade do |t|
-    t.string "name",  limit: 191
-    t.string "color", limit: 191
+    t.string "name",  limit: 255
+    t.string "color", limit: 255
   end
 
   create_table "register_tokens", force: :cascade do |t|
     t.string "uuid",  limit: 32,  null: false
     t.string "token", limit: 6,   null: false
-    t.string "email", limit: 191, null: false
+    t.string "email", limit: 191
   end
 
+  add_index "register_tokens", ["email"], name: "index_register_tokens_on_email", unique: true, using: :btree
   add_index "register_tokens", ["uuid"], name: "index_register_tokens_on_uuid", unique: true, using: :btree
 
   create_table "roles", force: :cascade do |t|
-    t.string  "name",  limit: 191
+    t.string  "name",  limit: 255
     t.integer "value", limit: 4
-    t.string  "color", limit: 191
+    t.string  "color", limit: 255
   end
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", limit: 191,   null: false
-    t.text     "data",       limit: 65535
+    t.string   "session_id", limit: 255,      null: false
+    t.text     "data",       limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", using: :btree
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", length: {"session_id"=>191}, using: :btree
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "threadreplies", force: :cascade do |t|
-    t.text     "content",        limit: 65535
+    t.text     "content",        limit: 16777215
     t.integer  "user_author_id", limit: 4
     t.integer  "user_editor_id", limit: 4
     t.integer  "forumthread_id", limit: 4
@@ -124,18 +127,18 @@ ActiveRecord::Schema.define(version: 20180606223258) do
   add_index "threadreplies", ["forumthread_id"], name: "index_threadreplies_on_forumthread_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "uuid",                        limit: 191,                   null: false
-    t.string   "name",                        limit: 191,                   null: false
-    t.string   "password_digest",             limit: 191,                   null: false
-    t.string   "ign",                         limit: 191,                   null: false
-    t.string   "email",                       limit: 191,                   null: false
+    t.string   "uuid",                        limit: 255,                   null: false
+    t.string   "name",                        limit: 191
+    t.string   "password_digest",             limit: 255,                   null: false
+    t.string   "ign",                         limit: 255,                   null: false
+    t.string   "email",                       limit: 191
     t.text     "about",                       limit: 65535
-    t.string   "last_ip",                     limit: 191
-    t.string   "skype",                       limit: 191
-    t.string   "youtube",                     limit: 191
-    t.string   "youtube_channelname",         limit: 191
-    t.string   "twitter",                     limit: 191
-    t.string   "email_token",                 limit: 191
+    t.string   "last_ip",                     limit: 255
+    t.string   "skype",                       limit: 255
+    t.string   "youtube",                     limit: 255
+    t.string   "youtube_channelname",         limit: 255
+    t.string   "twitter",                     limit: 255
+    t.string   "email_token",                 limit: 255
     t.boolean  "confirmed",                                 default: false
     t.datetime "last_seen"
     t.integer  "role_id",                     limit: 4,                     null: false
@@ -146,7 +149,7 @@ ActiveRecord::Schema.define(version: 20180606223258) do
     t.boolean  "mail_own_blogpost_comment",                 default: true
     t.boolean  "mail_other_blogpost_comment",               default: true
     t.boolean  "mail_mention",                              default: true
-    t.integer  "badge_id",                    limit: 4,     default: 1
+    t.integer  "badge_id",                    limit: 4,     default: 0
     t.boolean  "utc_time",                                  default: false
     t.boolean  "header_scroll",                             default: false
     t.boolean  "dark",                                      default: false
@@ -163,3 +166,4 @@ ActiveRecord::Schema.define(version: 20180606223258) do
   add_index "users", ["youtube"], name: "index_users_on_youtube", unique: true, using: :btree
 
 end
+


### PR DESCRIPTION
This pull request is intended to add the ability for users to configure a TOTP secret on a local authenticator to provide 2FA. Here's what it changes:
- Adds a TOTP code field to the login screen, and prevents log in if the code is incorrect for users with 2FA enabled.
- Adds the ability to configure a TOTP secret through a user's login settings page.