### PR TITLE
Dark theme improvement

### DIFF
--- a/app/assets/stylesheets/dark.css.scss
+++ b/app/assets/stylesheets/dark.css.scss
@@ -103,6 +103,12 @@ textarea {
 .notice {
     color:white;
 }
-.info-suggestions a:not(:hover) {
-    color: gray;
+.info-suggestions {
+    a:not(:hover) {
+        color: gray;
+    }
+
+    a:first-child {
+        border-right: 1px solid white !important;
+    }
 }

--- a/app/assets/stylesheets/dark.css.scss
+++ b/app/assets/stylesheets/dark.css.scss
@@ -103,3 +103,6 @@ textarea {
 .notice {
     color:white;
 }
+.info-suggestions a:not(:hover) {
+    color: gray;
+}


### PR DESCRIPTION
Turns this:
![image](https://user-images.githubusercontent.com/13370323/45927101-05b5c700-bf2e-11e8-8f91-3c70f0da4aec.png)

Into this:
![image](https://user-images.githubusercontent.com/13370323/45927181-6c87b000-bf2f-11e8-8dba-827a710a29f1.png)

(located at the bottom of info pages)